### PR TITLE
Pass error from failed image load to callback

### DIFF
--- a/packages/slate-drop-or-paste-images/src/load-image-file.js
+++ b/packages/slate-drop-or-paste-images/src/load-image-file.js
@@ -17,8 +17,12 @@ function loadImageFile(url, callback) {
     })
   } else {
     imageToDataUri(url, (err, uri) => {
-      const file = dataUriToBlob(uri)
-      callback(err, file)
+      if (err != null)
+        callback(err)
+      else {
+        const file = dataUriToBlob(uri)
+        callback(null, file)
+      }
     })
   }
 }


### PR DESCRIPTION
No uri will be passed to dataUriToBlob(uri) if there is an error loading the image so lets check for that and just pass along the error.